### PR TITLE
Chunk refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Every major / minor version release will be documented in the changelog.
 
+## v1.1.1 - 2020-09-01
+
+Better documentation, fixed issue with remote files mapped into a chunk object
+
 ## v1.0.0 - 2020-08-31
 
 Laravel Chunky first release. Main features:

--- a/README.md
+++ b/README.md
@@ -256,23 +256,26 @@ Chunky::deleteChunk('chunks-folder');
 The package include a method that, given the chunks folder, will return a sorted collection. Each item contains the relative chunk's path and index.
 
 ```php
-$chunks = Chunky::chunk('chunks-folder-name');
+$chunks = Chunky::chunks('chunks-folder-name');
 
 foreach($chunks as $chunk) {
-  print_r($chunk);
+  print_r($chunk->toArray());
 }
 
 //  [
 //    'index' => 0,
-//    'path'  => '/path/to/0_chunk.ext'
+//    'path'  => '/path/to/chunks-folder-name/0_chunk.ext',
+//    [...]
 //  ],
 //  [
 //    'index' => 1,
-//    'path'  => '/path/to/1_chunk.ext'
+//    'path'  => '/path/to/chunks-folder-name/1_chunk.ext',
+//    [...]
 //  ],
 //  [
 //    'index' => 2,
-//    'path'  => '/path/to/2_chunk.ext'
+//    'path'  => '/path/to/chunks-folder-name/2_chunk.ext',
+//    [...]
 //  ],
 //  ...
 ```

--- a/src/Chunk.php
+++ b/src/Chunk.php
@@ -66,7 +66,7 @@ class Chunk implements Arrayable, Jsonable, Responsable
      */
     public function getPath(): string
     {
-        if($this->path instanceof File) {
+        if ($this->path instanceof File) {
             return $this->path->getRealPath();
         }
 
@@ -75,9 +75,9 @@ class Chunk implements Arrayable, Jsonable, Responsable
 
     public function getFilename($suffix = null): string
     {
-        if($this->path instanceof UploadedFile) {
+        if ($this->path instanceof UploadedFile) {
             return basename($this->path->getClientOriginalName(), $suffix);
-        } elseif($this->path instanceof File) {
+        } elseif ($this->path instanceof File) {
             return $this->path->getBasename($suffix);
         }
 
@@ -94,7 +94,7 @@ class Chunk implements Arrayable, Jsonable, Responsable
 
     public function guessExtension()
     {
-        if($this->path instanceof File) {
+        if ($this->path instanceof File) {
             return $this->path->guessExtension();
         }
 
@@ -138,14 +138,15 @@ class Chunk implements Arrayable, Jsonable, Responsable
     }
 
     /**
-     * Retrive file contents
+     * Retrive file contents.
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      *
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
-    public function getFile() {
-        if($this->path instanceof File) {
+    public function getFile()
+    {
+        if ($this->path instanceof File) {
             return $this->path;
         }
 
@@ -160,7 +161,8 @@ class Chunk implements Arrayable, Jsonable, Responsable
      *
      * @return \Illuminate\Contracts\Filesystem\Filesystem
      */
-    public function filesystem() : Filesystem {
+    public function filesystem(): Filesystem
+    {
         return Container::getInstance()->make(FilesystemFactory::class)
             ->disk($this->getDisk());
     }
@@ -258,8 +260,8 @@ class Chunk implements Arrayable, Jsonable, Responsable
      */
     public function store(string $folder, $options = []): Chunk
     {
-        if(! $this->path instanceof File) {
-            throw new ChunkyException("Path must be a file");
+        if (! $this->path instanceof File) {
+            throw new ChunkyException('Path must be a file');
         }
 
         $chunk_name = $this->sanitizeName($this->index);

--- a/src/ChunksManager.php
+++ b/src/ChunksManager.php
@@ -185,7 +185,7 @@ class ChunksManager implements ChunksManagerContract
                 $filename = str_replace($folder.DIRECTORY_SEPARATOR, '', $path);
                 $exploded_name = explode('_', $filename);
                 $index = array_shift($exploded_name);
-                $last = count($files)-1 == $key;
+                $last = count($files) - 1 == $key;
 
                 return new Chunk(intval($index), $path, $this->getChunksDisk(), $last);
             })->sortBy(function (Chunk $chunk) {

--- a/src/ChunksManager.php
+++ b/src/ChunksManager.php
@@ -178,18 +178,18 @@ class ChunksManager implements ChunksManagerContract
      */
     public function chunks(string $folder): Collection
     {
-        return collect($this->chunksFilesystem()->files($folder))
-            ->map(function ($path) use ($folder) {
+        $files = $this->chunksFilesystem()->files($folder);
+
+        return collect($files)
+            ->map(function ($path, $key) use ($folder, $files) {
                 $filename = str_replace($folder.DIRECTORY_SEPARATOR, '', $path);
                 $exploded_name = explode('_', $filename);
                 $index = array_shift($exploded_name);
+                $last = count($files)-1 == $key;
 
-                return [
-                    'index' => intval($index),
-                    'path'  => $path,
-                ];
-            })->sortBy(function ($item) {
-                return $item['index'];
+                return new Chunk(intval($index), $path, $this->getChunksDisk(), $last);
+            })->sortBy(function (Chunk $chunk) {
+                return $chunk->getIndex();
             });
     }
 

--- a/src/Concerns/ChunksHelpers.php
+++ b/src/Concerns/ChunksHelpers.php
@@ -74,14 +74,9 @@ trait ChunksHelpers
 
         $files = $this->chunks($folder);
 
-        foreach ($files as $file) {
-            $chunk = new Chunk(
-                $file['index'],
-                new File($file['path'], false)
-            );
-
+        foreach ($files as $chunk) {
             $deleted = $this->chunksFilesystem()
-                ->delete($file['path']);
+                ->delete($chunk->getPath());
 
             if (! $deleted) {
                 return false;

--- a/src/Concerns/ChunksHelpers.php
+++ b/src/Concerns/ChunksHelpers.php
@@ -3,9 +3,7 @@
 namespace Jobtech\LaravelChunky\Concerns;
 
 use Illuminate\Support\Str;
-use Jobtech\LaravelChunky\Chunk;
 use Jobtech\LaravelChunky\Events\ChunkDeleted;
-use Symfony\Component\HttpFoundation\File\File;
 
 trait ChunksHelpers
 {

--- a/src/Facades/Chunky.php
+++ b/src/Facades/Chunky.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Jobtech\LaravelChunky;
+namespace Jobtech\LaravelChunky\Facades;
 
 use Illuminate\Support\Facades\Facade;
 

--- a/src/Strategies/Concerns/ChecksIntegrity.php
+++ b/src/Strategies/Concerns/ChecksIntegrity.php
@@ -14,10 +14,10 @@ trait ChecksIntegrity
             $this->chunksFolder()
         );
 
-        foreach ($chunks->all() as $chunk) {
-            $size = $this->chunksFilesystem()->size($chunk['path']);
+        foreach ($chunks as $chunk) {
+            $size = $this->chunksFilesystem()->size($chunk->getPath());
 
-            if ($size < $chunk_size && ! $this->isLastChunk($chunk['index'], $total_size, $chunk_size)) {
+            if ($size < $chunk_size && ! $this->isLastChunk($chunk->getIndex(), $total_size, $chunk_size)) {
                 return false;
             }
 

--- a/src/Strategies/MergeStrategy.php
+++ b/src/Strategies/MergeStrategy.php
@@ -4,6 +4,7 @@ namespace Jobtech\LaravelChunky\Strategies;
 
 use Illuminate\Container\Container;
 use Illuminate\Support\Traits\ForwardsCalls;
+use Jobtech\LaravelChunky\Chunk;
 use Jobtech\LaravelChunky\Contracts\ChunksManager;
 use Jobtech\LaravelChunky\Exceptions\StrategyException;
 use Jobtech\LaravelChunky\Strategies\Contracts\MergeStrategy as MergeStrategyContract;
@@ -45,8 +46,8 @@ abstract class MergeStrategy implements MergeStrategyContract
     {
         return $this->chunks(
             $this->folder
-        )->map(function ($chunk) {
-            return $chunk['path'];
+        )->map(function (Chunk $chunk) {
+            return $chunk->getPath();
         })->toArray();
     }
 

--- a/tests/Unit/ChunkTest.php
+++ b/tests/Unit/ChunkTest.php
@@ -63,7 +63,6 @@ class ChunkTest extends TestCase
      */
     public function chunk_has_attributes_from_file($index)
     {
-
         $chunk = new Chunk($index, $this->upload);
 
         $this->assertEquals($index, $chunk->getIndex());

--- a/tests/Unit/ChunksManagerTest.php
+++ b/tests/Unit/ChunksManagerTest.php
@@ -170,7 +170,8 @@ class ChunksManagerTest extends TestCase
     }
 
     /** @test */
-    public function manager_retrieves_chunks_from_folder() {
+    public function manager_retrieves_chunks_from_folder()
+    {
         $filesystem = $this->mock(Filesystem::class, function ($mock) {
             $mock->shouldReceive('files')
                 ->once()
@@ -179,7 +180,7 @@ class ChunksManagerTest extends TestCase
                     'chunks/foo/0_foo.ext',
                     'chunks/foo/1_foo.ext',
                     'chunks/foo/2_foo.ext',
-                    'chunks/foo/3_foo.ext'
+                    'chunks/foo/3_foo.ext',
                 ]);
         });
         $factory = $this->mock(Factory::class, function ($mock) use ($filesystem) {
@@ -187,7 +188,7 @@ class ChunksManagerTest extends TestCase
                 ->with('chunks')
                 ->andReturn($filesystem);
         });
-        $settings = $this->mock(ChunkySettings::class, function($mock) {
+        $settings = $this->mock(ChunkySettings::class, function ($mock) {
             $mock->shouldReceive('chunksDisk')
                 ->times(5)
                 ->andReturn('chunks');
@@ -198,7 +199,7 @@ class ChunksManagerTest extends TestCase
         $result = $manager->chunks('foo');
 
         $this->assertInstanceOf(Collection::class, $result);
-        $result->each(function($item) {
+        $result->each(function ($item) {
             $this->assertInstanceOf(Chunk::class, $item);
         });
     }

--- a/tests/Unit/ChunksManagerTest.php
+++ b/tests/Unit/ChunksManagerTest.php
@@ -5,6 +5,7 @@ namespace Jobtech\LaravelChunky\Tests\Unit;
 use Illuminate\Contracts\Filesystem\Factory;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Storage;
@@ -166,6 +167,40 @@ class ChunksManagerTest extends TestCase
             'disk' => 'merge',
             'foo'  => 'bar',
         ], $manager->getMergeOptions());
+    }
+
+    /** @test */
+    public function manager_retrieves_chunks_from_folder() {
+        $filesystem = $this->mock(Filesystem::class, function ($mock) {
+            $mock->shouldReceive('files')
+                ->once()
+                ->with('foo')
+                ->andReturn([
+                    'chunks/foo/0_foo.ext',
+                    'chunks/foo/1_foo.ext',
+                    'chunks/foo/2_foo.ext',
+                    'chunks/foo/3_foo.ext'
+                ]);
+        });
+        $factory = $this->mock(Factory::class, function ($mock) use ($filesystem) {
+            $mock->shouldReceive('disk')
+                ->with('chunks')
+                ->andReturn($filesystem);
+        });
+        $settings = $this->mock(ChunkySettings::class, function($mock) {
+            $mock->shouldReceive('chunksDisk')
+                ->times(5)
+                ->andReturn('chunks');
+        });
+
+        $manager = new ChunksManager($factory, $settings);
+
+        $result = $manager->chunks('foo');
+
+        $this->assertInstanceOf(Collection::class, $result);
+        $result->each(function($item) {
+            $this->assertInstanceOf(Chunk::class, $item);
+        });
     }
 
     /** @test */


### PR DESCRIPTION
Chunk class refactor, now it doesn't depend anymore to Symfony `File` component. In this way, remote files won't throw exception when mapped in a `Chunk` object 