### PR TITLE
Develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 .phpunit.result.cache
 .idea
 .env
+!phpunit.xml.dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 Every major / minor version release will be documented in the changelog.
 
+## v1.3.0 - 2020-11-2020
+Major updates:
+
+* Removed the merge strategy logic. It was completely useless since the package doesn't aim anymore to convert the files after merge.
+* Code refactor.
+* Temporary files support when merging from remote chunks disks.
+
+Minor fixes:
+
+* Improved tests.
+* Updated documentation.
+* Fixed Github actions
+
+## v1.2.2 - 2020-09-28
+Major features:
+
+* Removed all the logic regarding the mime-type strategy. It was out of context.
+* Splitted ChunksManager in two classes ChunksManager and MergeManager
+* Code cleanup
+* Better handling of remote chunks merge
+
+
 ## v1.1.5 - 2020-09-02
 * Little fixes on `Chunk` model. 
 * `MergeChunks` job refactor to avoid request serialization. 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <br />
 <p align="center">
   <a href="https://github.com/jobtech-dev/laravel-chunky">
-    <img src="https://user-images.githubusercontent.com/1577699/100443019-3c0ca500-30a9-11eb-9e36-72193abc90fc.png" alt="Logo">
+    <img src="https://user-images.githubusercontent.com/1577699/100456224-4ab28680-30c0-11eb-8452-e6a674f3dcdb.png" alt="Logo">
   </a>
 
   <h3 align="center">Laravel Chunky</h3>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <br />
 <p align="center">
   <a href="https://github.com/jobtech-dev/laravel-chunky">
-    <img src="https://jobtech.it/img/logo@2x.png" alt="Logo">
+    <img src="https://user-images.githubusercontent.com/1577699/100443019-3c0ca500-30a9-11eb-9e36-72193abc90fc.png" alt="Logo">
   </a>
 
   <h3 align="center">Laravel Chunky</h3>

--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
   <a href="https://github.com/jobtech-dev/laravel-chunky">
     <img src="https://user-images.githubusercontent.com/1577699/100456224-4ab28680-30c0-11eb-8452-e6a674f3dcdb.png" alt="Logo">
   </a>
-
-  <h3 align="center">Laravel Chunky</h3>
-
+  
   <p align="center">
     This package handles chunked files upload requests in order to safely save chunked files and, once the upload has been completed, merge all the chunks into a single file.
     <br />
@@ -42,7 +40,7 @@
 
 ## Getting Started
 
-Laravel chunky has been written to easily handle chunk upload for large files in Laravel 6.x, 7.x. and 8.x It will automatically handle the upload request (see the [usage](#usage) section below) and save all the chunks into the desired disk.
+Laravel chunky is a package that can handle chunk upload for large files in Laravel 6.x, 7.x. and 8.x. Its main goal is automatically handle the upload request (see the [usage](#usage) section below) and save all the chunks into the desired disk.
 
 Once the upload completes, the package will dispatch a job in order to merge all the files into a single one and save in the same chunks disks or in another one.
 

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,13 @@
 {
     "name": "jobtech/laravel-chunky",
     "description": "A laravel manager to handle chunked files upload",
+    "keywords": ["upload", "chunk", "laravel", "jobtech", "chunky"],
     "license": "MIT",
     "authors": [
         {
             "name": "ilGala",
-            "email": "filippo.galante@jobtech.it"
+            "email": "filippo.galante@jobtech.it",
+            "homepage": "https://jobtech.it"
         }
     ],
     "homepage": "https://github.com/jobtech-dev/laravel-chunky",

--- a/config/chunky.php
+++ b/config/chunky.php
@@ -22,6 +22,10 @@ return [
             'disk'   => env('CHUNKY_MERGE_DISK', 'local'),
             'folder' => null,
         ],
+        'tmp' => [
+            'disk'   => env('CHUNKY_TMP_DISK', 'local'),
+            'tmp' => null,
+        ],
     ],
 
     /*

--- a/config/chunky.php
+++ b/config/chunky.php
@@ -24,7 +24,7 @@ return [
         ],
         'tmp' => [
             'disk'   => env('CHUNKY_TMP_DISK', 'local'),
-            'tmp' => null,
+            'folder' => null,
         ],
     ],
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
 theme: jekyll-theme-minimal
 title: Laravel Chunky
 description: A laravel manager to handle chunked files upload
-logo: https://jobtech.it/img/logo@2x.png
+logo: https://user-images.githubusercontent.com/1577699/100443019-3c0ca500-30a9-11eb-9e36-72193abc90fc.png
 show_downloads: true

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
 theme: jekyll-theme-minimal
 title: Laravel Chunky
 description: A laravel manager to handle chunked files upload
-logo: https://user-images.githubusercontent.com/1577699/100443019-3c0ca500-30a9-11eb-9e36-72193abc90fc.png
+logo: https://user-images.githubusercontent.com/1577699/100456224-4ab28680-30c0-11eb-8452-e6a674f3dcdb.png
 show_downloads: true

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 <br />
 <p align="center">
   <a href="https://github.com/jobtech-dev/laravel-chunky">
-    <img src="https://user-images.githubusercontent.com/1577699/100443019-3c0ca500-30a9-11eb-9e36-72193abc90fc.png" alt="Logo">
+    <img src="https://user-images.githubusercontent.com/1577699/100456224-4ab28680-30c0-11eb-8452-e6a674f3dcdb.png" alt="Logo">
   </a>
 
   <h3 align="center">Laravel Chunky</h3>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 <br />
 <p align="center">
   <a href="https://github.com/jobtech-dev/laravel-chunky">
-    <img src="https://jobtech.it/img/logo@2x.png" alt="Logo">
+    <img src="https://user-images.githubusercontent.com/1577699/100443019-3c0ca500-30a9-11eb-9e36-72193abc90fc.png" alt="Logo">
   </a>
 
   <h3 align="center">Laravel Chunky</h3>

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,9 +3,7 @@
   <a href="https://github.com/jobtech-dev/laravel-chunky">
     <img src="https://user-images.githubusercontent.com/1577699/100456224-4ab28680-30c0-11eb-8452-e6a674f3dcdb.png" alt="Logo">
   </a>
-
-  <h3 align="center">Laravel Chunky</h3>
-
+  
   <p align="center">
     This package handles chunked files upload requests in order to safely save chunked files and, once the upload has been completed, merge all the chunks into a single file.
     <br />
@@ -42,7 +40,7 @@
 
 ## Getting Started
 
-Laravel chunky has been written to easily handle chunk upload for large files in Laravel 6.x, 7.x. and 8.x It will automatically handle the upload request (see the [usage](#usage) section below) and save all the chunks into the desired disk.
+Laravel chunky is a package that can handle chunk upload for large files in Laravel 6.x, 7.x. and 8.x. Its main goal is automatically handle the upload request (see the [usage](#usage) section below) and save all the chunks into the desired disk.
 
 Once the upload completes, the package will dispatch a job in order to merge all the files into a single one and save in the same chunks disks or in another one.
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,6 +20,10 @@
         </whitelist>
     </filter>
     <php>
-        <env name="APP_NAME" value="mysite"/>
+        <env name="CHUNKY_CHUNK_DISK" value="local"/>
+        <env name="CHUNKY_MERGE_DISK" value="local"/>
+        <env name="CHUNKY_AUTO_MERGE" value="true"/>
+        <env name="CHUNKY_MERGE_CONNECTION" value="default"/>
+        <env name="CHUNKY_MERGE_QUEUE" value="null"/>
     </php>
 </phpunit>

--- a/src/ChunkyServiceProvider.php
+++ b/src/ChunkyServiceProvider.php
@@ -64,7 +64,7 @@ class ChunkyServiceProvider extends ServiceProvider
 
     private function registerBindings()
     {
-        $this->app->singleton(TempFilesystem::class, function() {
+        $this->app->singleton(TempFilesystem::class, function () {
             $config = $this->app->make('config');
             $filesystem = new TempFilesystem(app()->make(Factory::class));
 

--- a/src/ChunkyServiceProvider.php
+++ b/src/ChunkyServiceProvider.php
@@ -3,12 +3,14 @@
 namespace Jobtech\LaravelChunky;
 
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Filesystem\Factory;
 use Illuminate\Foundation\Application as LaravelApplication;
 use Illuminate\Support\ServiceProvider;
 use Jobtech\LaravelChunky\Commands\ClearChunks;
 use Jobtech\LaravelChunky\Contracts\ChunkyManager as ChunkyManagerContract;
 use Jobtech\LaravelChunky\Support\ChunksFilesystem;
 use Jobtech\LaravelChunky\Support\MergeFilesystem;
+use Jobtech\LaravelChunky\Support\TempFilesystem;
 use Laravel\Lumen\Application as LumenApplication;
 
 class ChunkyServiceProvider extends ServiceProvider
@@ -62,6 +64,16 @@ class ChunkyServiceProvider extends ServiceProvider
 
     private function registerBindings()
     {
+        $this->app->singleton(TempFilesystem::class, function() {
+            $config = $this->app->make('config');
+            $filesystem = new TempFilesystem(app()->make(Factory::class));
+
+            $filesystem->disk($config->get('chunky.disks.tmp.disk', $config->get('filesystems.default')));
+            $filesystem->folder($config->get('chunky.disks.tmp.folder'));
+
+            return $filesystem;
+        });
+
         $this->app->bind(ChunksFilesystem::class, ChunksFilesystem::class);
         $this->app->bind(MergeFilesystem::class, MergeFilesystem::class);
 

--- a/src/Handlers/MergeHandler.php
+++ b/src/Handlers/MergeHandler.php
@@ -82,7 +82,7 @@ class MergeHandler implements MergeHandlerContract
     private function temporaryConcatenate(string $target, Collection $chunks)
     {
         $stream = new AppendStream;
-        $chunks->each(function (Chunk $chunk) use($stream) {
+        $chunks->each(function (Chunk $chunk) use ($stream) {
             $path = $this->temp_filesystem->store('tmp-'.$chunk->getFilename(), $this->chunksFilesystem()->readChunk($chunk->getPath()));
             $stream->append($this->temp_filesystem->readFile($path));
         });

--- a/src/Handlers/MergeHandler.php
+++ b/src/Handlers/MergeHandler.php
@@ -3,6 +3,7 @@
 namespace Jobtech\LaravelChunky\Handlers;
 
 use Illuminate\Container\Container;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Jobtech\LaravelChunky\Chunk;
 use Jobtech\LaravelChunky\Contracts\ChunkyManager;
@@ -12,6 +13,7 @@ use Jobtech\LaravelChunky\Exceptions\ChunksIntegrityException;
 use Jobtech\LaravelChunky\Exceptions\ChunkyException;
 use Jobtech\LaravelChunky\Http\Requests\AddChunkRequest;
 use Jobtech\LaravelChunky\Jobs\MergeChunks;
+use Jobtech\LaravelChunky\Support\TempFilesystem;
 use Keven\AppendStream\AppendStream;
 
 /**
@@ -31,9 +33,12 @@ class MergeHandler implements MergeHandlerContract
 
     private ?ChunkyManager $manager;
 
+    private TempFilesystem $temp_filesystem;
+
     public function __construct(?ChunkyManager $manager = null)
     {
         $this->manager = $manager;
+        $this->temp_filesystem = Container::getInstance()->make(TempFilesystem::class);
     }
 
     /**
@@ -46,18 +51,15 @@ class MergeHandler implements MergeHandlerContract
      */
     private function concatenate(string $folder, string $target): string
     {
-        // Merge
-        $chunks = $this->listChunks(
-            $folder,
-        )->map(function (Chunk $item) {
-            return $item->getPath();
-        });
-
         if (! $this->chunksFilesystem()->isLocal()) {
-            return $this->temporaryConcatenate($target, $chunks->toArray());
+            return $this->temporaryConcatenate($target, $this->listChunks($folder));
         }
 
+        $chunks = $this->listChunks($folder)->map(function (Chunk $item) {
+            return $item->getPath();
+        });
         $merge = $chunks->first();
+
         if (! $this->chunksFilesystem()->concatenate($merge, $chunks->toArray())) {
             throw new ChunkyException('Unable to concatenate chunks');
         }
@@ -72,35 +74,23 @@ class MergeHandler implements MergeHandlerContract
 
     /**
      * @param string $target
-     * @param array $chunks
+     * @param Collection $chunks
      * @return string
      * @throws \Illuminate\Contracts\Filesystem\FileExistsException
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
-    private function temporaryConcatenate(string $target, array $chunks)
+    private function temporaryConcatenate(string $target, Collection $chunks)
     {
         $stream = new AppendStream;
-        $tmp_streams = [];
+        $chunks->each(function (Chunk $chunk) use($stream) {
+            $path = $this->temp_filesystem->store('tmp-'.$chunk->getFilename(), $this->chunksFilesystem()->readChunk($chunk->getPath()));
+            $stream->append($this->temp_filesystem->readFile($path));
+        });
 
-        foreach ($chunks as $chunk) {
-            $chunk_stream = $this->chunksFilesystem()->readChunk($chunk);
-            $chunk_contents = stream_get_contents($chunk_stream);
-            fclose($chunk_stream);
+        $tmp_merge = $this->temp_filesystem->store($target, $stream->getResource());
+        $path = $this->mergeFilesystem()->store($target, $this->temp_filesystem->readFile($tmp_merge), $this->mergeOptions());
 
-            $tmp_stream = tmpfile();
-            fwrite($tmp_stream, $chunk_contents);
-            rewind($tmp_stream);
-            $stream->append($tmp_stream);
-            $tmp_streams[] = $tmp_stream;
-        }
-
-        $path = $this->mergeFilesystem()->store($target, $stream->getResource(), $this->mergeOptions());
-
-        foreach ($tmp_streams as $stream) {
-            if (is_resource($stream)) {
-                fclose($stream);
-            }
-        }
+        $this->temp_filesystem->clean();
 
         return $path;
     }

--- a/src/Support/ChunksFilesystem.php
+++ b/src/Support/ChunksFilesystem.php
@@ -11,12 +11,13 @@ use Jobtech\LaravelChunky\Events\ChunkDeleted;
 use Jobtech\LaravelChunky\Exceptions\ChunkyException;
 use Keven\Flysystem\Concatenate\Concatenate;
 use Symfony\Component\HttpFoundation\File\File;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
 class ChunksFilesystem extends Filesystem
 {
     /**
      * @param string $folder
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
     public function listChunks(string $folder): Collection
     {
@@ -70,7 +71,7 @@ class ChunksFilesystem extends Filesystem
     /**
      * @param string $path
      * @return resource|null
-     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     * @throws FileNotFoundException
      */
     public function readChunk(string $path)
     {
@@ -78,7 +79,7 @@ class ChunksFilesystem extends Filesystem
     }
 
     /**
-     * @param \Jobtech\LaravelChunky\Chunk $chunk
+     * @param Chunk $chunk
      * @param string $folder
      * @param array $options
      *
@@ -111,7 +112,7 @@ class ChunksFilesystem extends Filesystem
     /**
      * Delete all chunks and, once empty, delete the folder.
      *
-     * @param \Jobtech\LaravelChunky\Chunk $chunk
+     * @param Chunk $chunk
      * @return bool
      */
     public function deleteChunk(Chunk $chunk): bool

--- a/src/Support/ChunksFilesystem.php
+++ b/src/Support/ChunksFilesystem.php
@@ -2,6 +2,7 @@
 
 namespace Jobtech\LaravelChunky\Support;
 
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -11,7 +12,6 @@ use Jobtech\LaravelChunky\Events\ChunkDeleted;
 use Jobtech\LaravelChunky\Exceptions\ChunkyException;
 use Keven\Flysystem\Concatenate\Concatenate;
 use Symfony\Component\HttpFoundation\File\File;
-use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
 class ChunksFilesystem extends Filesystem
 {

--- a/src/Support/MergeFilesystem.php
+++ b/src/Support/MergeFilesystem.php
@@ -20,13 +20,9 @@ class MergeFilesystem extends Filesystem
     public function store(string $destination, $origin, $options = []): string
     {
         $destination = $this->path($destination);
-        if (is_resource($origin)) {
-            $origin = stream_get_contents($origin);
-        }
 
-        if ($this->filesystem()->disk($this->disk)->put($destination, $origin, $options)) {
+        if ($this->filesystem()->disk($this->disk)->writeStream($destination, $origin, $options)) {
             event(new MergeAdded($destination));
-
             return $destination;
         }
 

--- a/src/Support/MergeFilesystem.php
+++ b/src/Support/MergeFilesystem.php
@@ -23,6 +23,7 @@ class MergeFilesystem extends Filesystem
 
         if ($this->filesystem()->disk($this->disk)->writeStream($destination, $origin, $options)) {
             event(new MergeAdded($destination));
+
             return $destination;
         }
 

--- a/src/Support/TempFilesystem.php
+++ b/src/Support/TempFilesystem.php
@@ -2,8 +2,6 @@
 
 namespace Jobtech\LaravelChunky\Support;
 
-use Illuminate\Support\Facades\Log;
-
 class TempFilesystem extends Filesystem
 {
     private array $temp_files = [];
@@ -37,7 +35,7 @@ class TempFilesystem extends Filesystem
 
     public function clean()
     {
-        foreach($this->temp_files as $file) {
+        foreach ($this->temp_files as $file) {
             $this->filesystem()->disk($this->disk())->delete($file);
         }
     }

--- a/src/Support/TempFilesystem.php
+++ b/src/Support/TempFilesystem.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Jobtech\LaravelChunky\Support;
+
+use Illuminate\Support\Facades\Log;
+
+class TempFilesystem extends Filesystem
+{
+    private array $temp_files = [];
+
+    /**
+     * @param string $path
+     * @return resource|null
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    public function readFile(string $path)
+    {
+        return $this->filesystem()->disk($this->disk())->readStream($this->path($path));
+    }
+
+    /**
+     * @param string $path
+     * @param string|resource $resource
+     * @param array  $options
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileExistsException
+     * @return string
+     */
+    public function store(string $path, $resource = '', $options = []): string
+    {
+        $path = $this->path($path);
+        $this->filesystem()->disk($this->disk())->writeStream($path, $resource, $options);
+        $this->temp_files[] = $path;
+
+        return $path;
+    }
+
+    public function clean()
+    {
+        foreach($this->temp_files as $file) {
+            $this->filesystem()->disk($this->disk())->delete($file);
+        }
+    }
+}

--- a/tests/Unit/Support/MergeFilesystemTest.php
+++ b/tests/Unit/Support/MergeFilesystemTest.php
@@ -17,7 +17,7 @@ class MergeFilesystemTest extends TestCase
         parent::setUp();
 
         $this->filesystem = MergeFilesystem::instance([
-            'folder' => 'foo'
+            'folder' => 'foo',
         ]);
     }
 

--- a/tests/Unit/Support/MergeFilesystemTest.php
+++ b/tests/Unit/Support/MergeFilesystemTest.php
@@ -17,7 +17,7 @@ class MergeFilesystemTest extends TestCase
         parent::setUp();
 
         $this->filesystem = MergeFilesystem::instance([
-            'folder' => 'foo',
+            'folder' => 'foo'
         ]);
     }
 
@@ -25,7 +25,7 @@ class MergeFilesystemTest extends TestCase
     public function filesystem_stores_file()
     {
         Event::fake();
-        $this->filesystem->store('text.txt', $this->filesystem->read('chunks/foo/0_chunk.txt'));
+        $this->filesystem->store('text.txt', $this->filesystem->readStream('chunks/foo/0_chunk.txt'));
 
         Storage::assertExists('foo/text.txt');
         Event::assertDispatched(MergeAdded::class);


### PR DESCRIPTION
🛠️ Major updates:

After a few tests, there was a RAM  memory usage pick (10x the file dimension) when the stream of a PHP temporary file was written into S3.

In detail, if the `ChunkFilesystem` has a remote adapter (S3 adapter tested) in order to generate the merge file, local temporary files are generated from remote chunks and, once appended to the final file, a stream is opened and putted as resource object into S3. This very last operation, mesured with `memory_get_peak_usage`, was about ten times the dimension of the remote chunks sum.

To avoid this behaviour, `TemporaryFilesystem` has been introduced and the memory pick has been optimized.

🔨 Minor updates:

* New logo!
* Readme update